### PR TITLE
Adds v basic kubernetes example

### DIFF
--- a/k8s-example/cronjob.yaml
+++ b/k8s-example/cronjob.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opsgenie-report
+  namespace: oncall-scheduler
+spec:
+  schedule: "0 6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: opsgenie-report
+            image: quay.io/giantswarm/oncall-scheduler:latest
+            imagePullPolicy: Always
+            args:
+            - report
+            - alert
+            - --opsgenie-api-key=$(opsgenie-api-key)
+            - --slack-channel=test_bot
+            - --slack-token=$(slack-token)
+            env:
+            - name: opsgenie-api-key
+              valueFrom:
+                secretKeyRef:
+                  name: oncall-scheduler
+                  key: opsgenie-api-key
+            - name: slack-token
+              valueFrom:
+                secretKeyRef:
+                  name: oncall-scheduler
+                  key: slack-token
+          restartPolicy: Never

--- a/k8s-example/secret.yaml
+++ b/k8s-example/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oncall-scheduler
+  namespace: oncall-scheduler
+type: Opaque
+data:
+  opsgenie-api-key: OPSGENIE-API-KEY
+  slack-token: SLACK-TOKEN


### PR DESCRIPTION
I probably won't have time in the hackathon to sort out helm chart and draughtsman and such, so dumping my v. basic kubernetes manifests for now, so I can sort them into a proper chart later.

Basically, docs / saving stuff :D