### PR TITLE
Moves to team aware reporting

### DIFF
--- a/cmd/report/alert/runner.go
+++ b/cmd/report/alert/runner.go
@@ -66,12 +66,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
-	summary, err := opsgenie.GetAlertSummary()
+	summary, err := opsgenie.GetSummary()
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = slack.PostAlertSummary(summary)
+	err = slack.PostSummary(summary)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spf13/cobra v0.0.5
 )
+
+go 1.13

--- a/pkg/opsgenieclient/client_alert_test.go
+++ b/pkg/opsgenieclient/client_alert_test.go
@@ -74,7 +74,7 @@ func Test_CalculatePercentageChange(t *testing.T) {
 			name:           "case 1: 0 change to 1",
 			input_a:        0,
 			input_b:        1,
-			expectedOutput: 0,
+			expectedOutput: 100,
 		},
 		{
 			name:           "case 2: 1 change to 0",

--- a/pkg/slackclient/client_summary.go
+++ b/pkg/slackclient/client_summary.go
@@ -3,17 +3,27 @@ package slackclient
 import (
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/oncall-scheduler/pkg/opsgenieclient"
 	"github.com/nlopes/slack"
 )
 
-func (c *Client) PostAlertSummary(summary opsgenieclient.AlertSummary) error {
+func (c *Client) PostSummary(summary opsgenieclient.Summary) error {
+	teamNames := []string{}
+	for teamName := range summary {
+		teamNames = append(teamNames, teamName)
+	}
+	sort.Strings(teamNames)
+
 	attachments := []slack.Attachment{}
 
-	for _, summaryItem := range summary {
-		attachment := c.buildAttachment(summaryItem)
+	for _, teamName := range teamNames {
+		alertSummary := summary[teamName]
+
+		attachment := c.buildAlertSummaryAttachment(teamName, alertSummary)
 		attachments = append(attachments, attachment)
 	}
 
@@ -30,26 +40,56 @@ func (c *Client) PostAlertSummary(summary opsgenieclient.AlertSummary) error {
 	return nil
 }
 
-// buildAttachment builds a Slack attachment for a given AlertSummaryItem.
-// See https://api.slack.com/docs/formatting for formatting docs.
-func (c *Client) buildAttachment(summaryItem opsgenieclient.AlertSummaryItem) slack.Attachment {
-	attachment := slack.Attachment{
-		Text: fmt.Sprintf("%v alerts over the last %v", summaryItem.Count, summaryItem.Display),
+func (c *Client) buildAlertSummaryAttachment(team string, summaryItem opsgenieclient.AlertSummary) slack.Attachment {
+	name := c.formatTeamName(team)
+
+	t := ""
+	for _, item := range summaryItem {
+		absChange := int(math.Abs(float64(item.Change)))
+
+		switch change := item.Change; {
+		case change < 0:
+			t = t + fmt.Sprintf("%v alerts over the last %v (%v fewer alerts, decrease of %v%%)\n", item.Count, item.Display, item.PreviousCount-item.Count, absChange)
+		case change == 0:
+			t = t + fmt.Sprintf("%v alerts over the last %v, same as previous\n", item.Count, item.Display)
+		default:
+			t = t + fmt.Sprintf("%v alerts over the last %v (%v more alerts, increase of %v%%)\n", item.Count, item.Display, item.Count-item.PreviousCount, absChange)
+		}
 	}
 
-	absChange := int(math.Abs(float64(summaryItem.Change)))
+	color := ""
+	numGoods := 0
+	for _, item := range summaryItem {
+		if item.Change <= 0 {
+			numGoods++
+		}
+	}
+	switch numGoods {
+	case 3:
+		color = "#28a745"
+	case 2:
+		color = "#007bff"
+	case 1:
+		color = "#ffc107"
+	case 0:
+		color = "#dc3545"
+	}
 
-	switch change := summaryItem.Change; {
-	case change < 0:
-		attachment.Color = "good"
-		attachment.Footer = fmt.Sprintf("Decrease of %v%%, %v fewer alerts!", absChange, summaryItem.PreviousCount-summaryItem.Count)
-	case change == 0:
-		attachment.Color = "info"
-		attachment.Footer = "No change~"
-	default:
-		attachment.Color = "danger"
-		attachment.Footer = fmt.Sprintf("Increase of %v%%, %v more alerts", absChange, summaryItem.Count-summaryItem.PreviousCount)
+	attachment := slack.Attachment{
+		Title: name,
+		Text:  t,
+		Color: color,
 	}
 
 	return attachment
+}
+
+func (c *Client) formatTeamName(name string) string {
+	if strings.HasSuffix(name, "_team") {
+		name = strings.Replace(name, "_team", "", 1)
+	}
+
+	name = strings.Title(name)
+
+	return name
 }


### PR DESCRIPTION
The previous daily OpsGenie report, see:
<img width="303" alt="Screen Shot 2020-01-30 at 15 45 32" src="https://user-images.githubusercontent.com/297653/73464963-96e54b00-4377-11ea-8f77-99f71b26fa7c.png">
doesn't take teams into account, which means we lack visibility on alert spread, team health, etc.

This changeset updates the report to take teams into account, see:
<img width="518" alt="Screen Shot 2020-01-30 at 15 46 27" src="https://user-images.githubusercontent.com/297653/73465045-b11f2900-4377-11ea-81b1-b5ca9e5d2b34.png">
which should give us better visibility into how we're doing.

Bam!