### PR TITLE
Add more info regarding business hours / non-business hours alerts

### DIFF
--- a/cmd/report/alert/flag.go
+++ b/cmd/report/alert/flag.go
@@ -13,7 +13,7 @@ const (
 
 const (
 	defaultOpsGenieAPIKey = ""
-	defaultSlackChannel   = "test_bot" // TODO: Change to #ops.
+	defaultSlackChannel   = "ops" // TODO: Change to #ops.
 	defaultSlackToken     = ""
 )
 

--- a/cmd/report/alert/flag.go
+++ b/cmd/report/alert/flag.go
@@ -13,7 +13,7 @@ const (
 
 const (
 	defaultOpsGenieAPIKey = ""
-	defaultSlackChannel   = "ops" // TODO: Change to #ops.
+	defaultSlackChannel   = "ops"
 	defaultSlackToken     = ""
 )
 

--- a/pkg/opsgenieclient/client_alert_test.go
+++ b/pkg/opsgenieclient/client_alert_test.go
@@ -54,7 +54,7 @@ func Test_GetUnixTime(t *testing.T) {
 	}
 }
 
-func Test_CalculatePercentageChange(t *testing.T) {
+func Test_CalculateChange(t *testing.T) {
 	testCases := []struct {
 		name           string
 		input_a        int
@@ -106,7 +106,7 @@ func Test_CalculatePercentageChange(t *testing.T) {
 				t.Fatalf("could not create client: %#v", err)
 			}
 
-			output := client.calculatePercentageChange(tc.input_a, tc.input_b)
+			_, output := client.calculateChange(tc.input_a, tc.input_b)
 
 			if output != tc.expectedOutput {
 				t.Fatalf("wanted: %v, got: %v", tc.expectedOutput, output)

--- a/pkg/slackclient/client_summary.go
+++ b/pkg/slackclient/client_summary.go
@@ -44,12 +44,9 @@ func (c *Client) buildAlertSummaryAttachment(team string, summaryItem opsgeniecl
 
 	t := ""
 	for _, item := range summaryItem {
-		totalDiff := diff(item.CurrentCount.Total, item.PreviousCount.Total)
-		total := fmt.Sprintf("total: %v (%v|%v%%)", item.CurrentCount.Total, totalDiff, item.Change.Total)
-		businessHoursDiff := diff(item.CurrentCount.BusinessHours, item.PreviousCount.BusinessHours)
-		businessHours := fmt.Sprintf("bh: %v (%v|%v%%)", item.CurrentCount.BusinessHours, businessHoursDiff, item.Change.BusinessHours)
-		nonBusinessHoursDiff := diff(item.CurrentCount.NonBusinessHours, item.PreviousCount.NonBusinessHours)
-		nonBusinessHours := fmt.Sprintf("nbh: %v (%v|%v%%)", item.CurrentCount.NonBusinessHours, nonBusinessHoursDiff, item.Change.NonBusinessHours)
+		total := fmt.Sprintf("total: *%v* (%v|%v%%)", item.CurrentCount.Total, item.Change.Diff.Total, item.Change.Percentage.Total)
+		businessHours := fmt.Sprintf("bh: *%v* (%v|%v%%)", item.CurrentCount.BusinessHours, item.Change.Diff.BusinessHours, item.Change.Percentage.BusinessHours)
+		nonBusinessHours := fmt.Sprintf("nbh: *%v* (%v|%v%%)", item.CurrentCount.NonBusinessHours, item.Change.Diff.NonBusinessHours, item.Change.Percentage.NonBusinessHours)
 
 		t = t + fmt.Sprintf("Last %v: %s | %s | %s. \n", item.Display, total, businessHours, nonBusinessHours)
 	}
@@ -57,7 +54,7 @@ func (c *Client) buildAlertSummaryAttachment(team string, summaryItem opsgeniecl
 	color := ""
 	numGoods := 0
 	for _, item := range summaryItem {
-		if item.Change.Total <= 0 {
+		if item.Change.Diff.Total <= 0 {
 			numGoods++
 		}
 	}
@@ -89,19 +86,4 @@ func (c *Client) formatTeamName(name string) string {
 	name = strings.Title(name)
 
 	return name
-}
-
-func diff(num1, num2 int) string {
-	var diff string
-
-	switch change := num1 - num2; {
-	case change < 0:
-		diff = fmt.Sprintf("-%d", num2-num1)
-	case change == 0:
-		diff = "0"
-	default:
-		diff = fmt.Sprintf("+%d", num1-num2)
-	}
-
-	return diff
 }


### PR DESCRIPTION
It now counts total pages with business hours(bh) and non-business hours (nbh) info
Alerts_router is a team which gets all the alerts. So that's a summary for all teams.
Then there is info per team with total, b/h and nb/h and +/- in case it increased or decreased.
This gives us more info regarding alerts state per team, per business period and in total.
It might be it is a bit hard to read at the beginning, but using whole words like increased/decreased etc makes strings really long and whole summary takes 2 screens. All the valuable info is in summary.

---

![a0c48d7b-71c1-4faf-98c5-68f4a6f39c04](https://user-images.githubusercontent.com/1071648/77173800-c0de0280-6ac8-11ea-8c51-bd443c06a79f.png)
